### PR TITLE
Add highlight.js integration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
   <title>Presentación Spring Boot y Spring Framework</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/theme/black.css" id="theme">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.8.0/styles/monokai.css">
   <!-- Para cambiar el tema reemplaza el enlace anterior por otro de la carpeta theme -->
   <link rel="stylesheet" href="assets/css/custom.css"><!-- Estilos personalizados -->
 </head>
@@ -18,12 +19,12 @@
   </div>
   <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/plugin/markdown/markdown.js"></script>
-  <!-- Habilita highlight.js o zoom agregando sus scripts y plugins -->
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/plugin/highlight/highlight.js"></script>
   <script>
     Reveal.initialize({
       hash: true,
       slideNumber: true,
-      plugins: [ RevealMarkdown ]
+      plugins: [ RevealMarkdown, RevealHighlight ]
       // Puedes cambiar la transición con transition: 'fade', etc.
     });
   </script>

--- a/public/slides/slide-1.md
+++ b/public/slides/slide-1.md
@@ -2,7 +2,7 @@
 
 
 <section>
-  <pre><code data-trim data-noescape>
+  <pre><code class="language-clojure" data-trim data-noescape>
 (def lazy-fib
   (concat
    [0 1]


### PR DESCRIPTION
## Summary
- enable syntax highlighting using highlight.js CDN
- initialize RevealHighlight plugin
- mark code blocks with language classes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687460c2ddbc833384edfc755c6a7554